### PR TITLE
Remove css link tag

### DIFF
--- a/app/views/layouts/pdf.html.erb
+++ b/app/views/layouts/pdf.html.erb
@@ -3,7 +3,6 @@
 
 <head>
   <title>PDFs - Ruby on Rails</title>
-  <%= wicked_pdf_stylesheet_link_tag "invoice" %>
   <link rel="stylesheet" href="../../assets/stylesheets/cooler.css" />
 </head>
 


### PR DESCRIPTION
The wicked_pdf gem had a css link tag which pointed to a non-existent file, causing application error on Heroku. 